### PR TITLE
Remove nix from main workflows

### DIFF
--- a/.github/workflows/ci-nix.yaml
+++ b/.github/workflows/ci-nix.yaml
@@ -1,0 +1,65 @@
+name: CI (with Nix)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+permissions: read-all
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: nix develop .#ci -c bash {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Nix shell
+        run: echo
+
+      - name: Test
+        run: make test
+
+      - name: Annotate tests
+        uses: guyarb/golang-test-annotations@9ab2ea84a399d03ffd114bf49dd23ffadc794541 # v0.6.0
+        if: always()
+        with:
+          test-results: build/test.json
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: nix develop .#ci -c bash {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
+
+      - name: Set up Nix
+        uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Nix shell
+        run: echo
+
+      - name: Lint
+        run: make lint
+        env:
+          LINT_ARGS: --out-format=github-actions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,22 +12,17 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        shell: nix develop .#ci -c bash {0}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
-      - name: Set up Nix
-        uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          go-version: '1.20'
 
-      - name: Prepare Nix shell
-        run: echo
+      - name: Set up gotestsum
+        run: make bin/gotestsum
 
       - name: Test
         run: make test
@@ -42,27 +37,14 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
 
-    defaults:
-      run:
-        shell: nix develop .#ci -c bash {0}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
-      - name: Set up Nix
-        uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare Nix shell
-        run: echo
-
       - name: Lint
-        run: make lint
-        env:
-          LINT_ARGS: --out-format=github-actions
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.52.2
 
   artifacts:
     name: Artifacts

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,22 +23,12 @@ jobs:
     needs: [ artifacts ]
     environment: production
 
-    defaults:
-      run:
-        shell: nix develop .#ci -c bash {0}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3.5.0
 
-      - name: Set up Nix
-        uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-
-      - name: Prepare Nix shell
-        run: echo
+      - name: Fly.io CLI
+        uses: superfly/flyctl-actions/setup-flyctl@1.3
 
       - name: Deploy
         run: flyctl deploy --image ${{ needs.artifacts.outputs.container-image-ref }}


### PR DESCRIPTION
As much as I love Nix and think that it should be the de facto package manager for every software development project, this toy project is supposed to showcase basic development workflows and the reality is that most projects don't use Nix.